### PR TITLE
Improve Child Coordinator Retention

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -132,9 +132,11 @@ whitelist_rules:
   - opening_brace
   - operator_usage_whitespace
   - operator_whitespace
+  - optional_enum_case_matching
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
   - private_action
   - private_outlet
   - private_over_fileprivate

--- a/Minerva.podspec
+++ b/Minerva.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Minerva"
-  s.version = "2.14.3"
+  s.version = "2.15.0"
   s.license = { :type => 'MIT', :file => 'LICENSE' }
 
   s.summary = "A Swift MVVM + Coordinator Framework"

--- a/MinervaCatalog/Core/CatalogPresenter.swift
+++ b/MinervaCatalog/Core/CatalogPresenter.swift
@@ -5,12 +5,13 @@
 //
 
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
 public final class CatalogPresenter: Presenter {
-  public lazy var sections: Observable<[ListSection]> = Observable.just(
-    [
+  public lazy var sections: BehaviorRelay<[ListSection]> = BehaviorRelay(
+    value: [
       createButtonCellModelSection(),
       createButtonImageCellModelSection(),
       createDatePickerCellModelSection(),

--- a/MinervaExample/CreateUser/CreateUserPresenter.swift
+++ b/MinervaExample/CreateUser/CreateUserPresenter.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -18,11 +19,10 @@ public final class CreateUserPresenter: Presenter {
   private static let passwordCellModelIdentifier = "passwordCellModelIdentifier"
   private static let caloriesCellModelIdentifier = "caloriesCellModelIdentifier"
 
-  private let actionsSubject = PublishSubject<Action>()
-  public var actions: Observable<Action> { actionsSubject.asObservable() }
+  private let actionsRelay = PublishRelay<Action>()
+  public var actions: Observable<Action> { actionsRelay.asObservable() }
 
-  private let sectionsSubject = BehaviorSubject<[ListSection]>(value: [])
-  public var sections: Observable<[ListSection]> { sectionsSubject.asObservable() }
+  public var sections = BehaviorRelay<[ListSection]>(value: [])
 
   private let disposeBag = DisposeBag()
 
@@ -32,7 +32,7 @@ public final class CreateUserPresenter: Presenter {
   private var role: UserRole = .user
 
   public init() {
-    sectionsSubject.onNext([createSection()])
+    sections.accept([createSection()])
   }
 
   // MARK: - Private
@@ -56,7 +56,7 @@ public final class CreateUserPresenter: Presenter {
         password: strongSelf.password,
         dailyCalories: strongSelf.dailyCalories,
         role: strongSelf.role)
-      strongSelf.actionsSubject.onNext(action)
+      strongSelf.actionsRelay.accept(action)
     }
 
     return [

--- a/MinervaExample/EditWorkout/EditWorkoutPresenter.swift
+++ b/MinervaExample/EditWorkout/EditWorkoutPresenter.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -18,11 +19,10 @@ public final class EditWorkoutPresenter: Presenter {
   private static let caloriesCellModelIdentifier = "CaloriesCellModel"
   private static let textCellModelIdentifier = "TextCellModel"
 
-  private let actionsSubject = PublishSubject<Action>()
-  public var actions: Observable<Action> { actionsSubject.asObservable() }
+  private let actionsRelay = PublishRelay<Action>()
+  public var actions: Observable<Action> { actionsRelay.asObservable() }
 
-  private let sectionsSubject = BehaviorSubject<[ListSection]>(value: [])
-  public var sections: Observable<[ListSection]> { sectionsSubject.asObservable() }
+  public var sections = BehaviorRelay<[ListSection]>(value: [])
 
   private let disposeBag = DisposeBag()
 
@@ -39,7 +39,7 @@ public final class EditWorkoutPresenter: Presenter {
     self.workout = workout.proto
     self.workoutSubject = BehaviorSubject<WorkoutProto>(value: self.workout)
     workoutSubject.map({ [weak self] workout -> [ListSection] in self?.createSection(with: workout) ?? [] })
-      .subscribe(sectionsSubject)
+      .bind(to: sections)
       .disposed(by: disposeBag)
   }
 
@@ -62,7 +62,7 @@ public final class EditWorkoutPresenter: Presenter {
     doneModel.textColor = .selectable
     doneModel.selectionAction = { [weak self] _, _ -> Void in
       guard let strongSelf = self else { return }
-      strongSelf.actionsSubject.onNext(.save(workout: strongSelf.workout))
+      strongSelf.actionsRelay.accept(.save(workout: strongSelf.workout))
     }
 
     return [

--- a/MinervaExample/Onboarding/SignInPresenter.swift
+++ b/MinervaExample/Onboarding/SignInPresenter.swift
@@ -5,6 +5,7 @@
 //
 
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -29,11 +30,10 @@ public final class SignInPresenter: Presenter {
     }
   }
 
-  private let actionsSubject = PublishSubject<Action>()
-  public var actions: Observable<Action> { actionsSubject.asObservable() }
+  private let actionsRelay = PublishRelay<Action>()
+  public var actions: Observable<Action> { actionsRelay.asObservable() }
 
-  private let sectionsSubject = BehaviorSubject<[ListSection]>(value: [])
-  public var sections: Observable<[ListSection]> { sectionsSubject.asObservable() }
+  public var sections = BehaviorRelay<[ListSection]>(value: [])
 
   private let disposeBag = DisposeBag()
 
@@ -46,7 +46,7 @@ public final class SignInPresenter: Presenter {
 
   public init(mode: Mode) {
     self.mode = mode
-    sectionsSubject.onNext([createSection()])
+    sections.accept([createSection()])
   }
 
   // MARK: - Private
@@ -96,9 +96,9 @@ public final class SignInPresenter: Presenter {
 
   private func handleContinueButtonPress() {
     if let email = self.email, let password = self.password {
-      actionsSubject.onNext(.signIn(email: email, password: password, mode: self.mode))
+      actionsRelay.accept(.signIn(email: email, password: password, mode: self.mode))
     } else {
-      actionsSubject.onNext(.invalidInput)
+      actionsRelay.accept(.invalidInput)
     }
   }
 

--- a/MinervaExample/Onboarding/WelcomePresenter.swift
+++ b/MinervaExample/Onboarding/WelcomePresenter.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -15,16 +16,15 @@ public final class WelcomePresenter: Presenter {
     case login
   }
 
-  private let actionsSubject = PublishSubject<Action>()
-  public var actions: Observable<Action> { actionsSubject.asObservable() }
+  private let actionsRelay = PublishRelay<Action>()
+  public var actions: Observable<Action> { actionsRelay.asObservable() }
 
-  private let sectionsSubject = BehaviorSubject<[ListSection]>(value: [])
-  public var sections: Observable<[ListSection]> { sectionsSubject.asObservable() }
+  public var sections = BehaviorRelay<[ListSection]>(value: [])
 
   private let disposeBag = DisposeBag()
 
   public init() {
-    sectionsSubject.onNext([createSection()])
+    sections.accept([createSection()])
   }
 
   // MARK: - Private
@@ -65,14 +65,14 @@ public final class WelcomePresenter: Presenter {
     newAccountModel.buttonColor = .selectable
     newAccountModel.buttonAction = { [weak self] _, _ in
       guard let strongSelf = self else { return }
-      strongSelf.actionsSubject.onNext(.createAccount)
+      strongSelf.actionsRelay.accept(.createAccount)
     }
 
     let existingAccountModel = SelectableLabelCellModel(text: "USE EXISTING ACCOUNT", font: .subheadline)
     existingAccountModel.textAlignment = .center
     existingAccountModel.selectionAction = { [weak self] _, _ -> Void in
       guard let strongSelf = self else { return }
-      strongSelf.actionsSubject.onNext(.login)
+      strongSelf.actionsRelay.accept(.login)
     }
     existingAccountModel.textColor = .selectable
     existingAccountModel.directionalLayoutMargins.top = 30

--- a/MinervaExample/UserList/UserListVC.swift
+++ b/MinervaExample/UserList/UserListVC.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -16,10 +17,10 @@ public final class UserListVC: BaseViewController {
   }
 
   public var actions: Observable<Action> {
-    actionsSubject.asObservable()
+    actionsRelay.asObservable()
   }
 
-  private let actionsSubject: PublishSubject<Action>
+  private let actionsRelay: PublishRelay<Action>
   private let listController = LegacyListController()
 
   private let addButton: UIButton = {
@@ -33,7 +34,7 @@ public final class UserListVC: BaseViewController {
   // MARK: - Lifecycle
 
   public required init() {
-    self.actionsSubject = PublishSubject()
+    self.actionsRelay = PublishRelay()
     super.init()
 
     collectionView.contentInsetAdjustmentBehavior = .never
@@ -72,6 +73,6 @@ public final class UserListVC: BaseViewController {
 
   @objc
   private func addButtonPressed() {
-    actionsSubject.on(.next(.createUser))
+    actionsRelay.accept(.createUser)
   }
 }

--- a/MinervaExample/Workout/WorkoutPresenter.swift
+++ b/MinervaExample/Workout/WorkoutPresenter.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 import UIKit
 
@@ -27,11 +28,10 @@ public final class WorkoutPresenter: Presenter {
     public var loading: Bool = false
   }
 
-  private let actionsSubject = PublishSubject<Action>()
-  public var actions: Observable<Action> { actionsSubject.asObservable() }
+  private let actionsRelay = PublishRelay<Action>()
+  public var actions: Observable<Action> { actionsRelay.asObservable() }
 
-  private let sectionsSubject = BehaviorSubject<[ListSection]>(value: [])
-  public var sections: Observable<[ListSection]> { sectionsSubject.asObservable() }
+  public var sections = BehaviorRelay<[ListSection]>(value: [])
 
   private let persistentStateSubject = BehaviorSubject(value: PersistentState())
   public var persistentState: Observable<PersistentState> { persistentStateSubject.asObservable() }
@@ -84,15 +84,15 @@ public final class WorkoutPresenter: Presenter {
   }
 
   public func editFilter() {
-    actionsSubject.onNext(.editFilter)
+    actionsRelay.accept(.editFilter)
   }
 
   public func createWorkout() {
-    actionsSubject.onNext(.createWorkout(userID: repository.userID))
+    actionsRelay.accept(.createWorkout(userID: repository.userID))
   }
 
   public func edit(workout: Workout) {
-    actionsSubject.onNext(.editWorkout(workout))
+    actionsRelay.accept(.editWorkout(workout))
   }
 
   public func delete(workout: Workout) {
@@ -139,7 +139,7 @@ public final class WorkoutPresenter: Presenter {
       workouts: workouts,
       user: user
     )
-    sectionsSubject.onNext(sections)
+    self.sections.accept(sections)
 
     let persistentState = PersistentState(title: user.email, filter: filter)
     persistentStateSubject.onNext(persistentState)

--- a/MinervaTests/Fakes/FakePresenter.swift
+++ b/MinervaTests/Fakes/FakePresenter.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Minerva
+import RxRelay
 import RxSwift
 
 public final class FakePresenter: Presenter {
@@ -77,6 +78,7 @@ public final class FakePresenter: Presenter {
   }()
 
   public let listSections: [ListSection]
+  public let sections: BehaviorRelay<[ListSection]>
 
   public init() {
     let mainSection = ListSection(cellModels: cellModels, identifier: "Section")
@@ -90,9 +92,6 @@ public final class FakePresenter: Presenter {
     var horizontalSection = ListSection(cellModels: [horizontalCellModel], identifier: "HorizontalSection")
     horizontalSection.constraints.scrollDirection = .horizontal
     listSections = [mainSection, horizontalSection]
-  }
-
-  public var sections: Observable<[ListSection]> {
-    return .just(listSections)
+    sections = BehaviorRelay<[ListSection]>(value: listSections)
   }
 }

--- a/MinervaTests/Tests/CoordinationTests.swift
+++ b/MinervaTests/Tests/CoordinationTests.swift
@@ -67,6 +67,27 @@ public final class CoordinationTests: XCTestCase {
     XCTAssertTrue(rootCoordinator.childCoordinators.isEmpty)
   }
 
+  public func testDismissalFromNavigator() {
+    XCTAssertNotNil(rootCoordinator.viewController.view)
+    let childCoordinator = FakeCoordinator()
+    let navigator = BasicNavigator(parent: rootCoordinator.navigator)
+    let presentationExpectation = expectation(description: "Presentation")
+    rootCoordinator.present(childCoordinator, from: navigator, animated: false) {
+      presentationExpectation.fulfill()
+    }
+    wait(for: [presentationExpectation], timeout: 5)
+
+    XCTAssertTrue(rootCoordinator.childCoordinators.contains { $0 === childCoordinator })
+
+    let dismissalExpectation = expectation(description: "Dismissal")
+    dismissalExpectation.assertForOverFulfill = false
+    navigator.dismiss(childCoordinator.viewController, animated: false) {
+      dismissalExpectation.fulfill()
+    }
+    wait(for: [dismissalExpectation], timeout: 5)
+    XCTAssertTrue(rootCoordinator.childCoordinators.isEmpty)
+  }
+
   public func testPushAndPop() {
     XCTAssertNotNil(rootCoordinator.viewController.view)
     let childCoordinator = FakeCoordinator(navigator: rootCoordinator.navigator)

--- a/MinervaTests/Tests/ListTests.swift
+++ b/MinervaTests/Tests/ListTests.swift
@@ -154,11 +154,15 @@ public final class ListTests: XCTestCase {
       updateExpectation.fulfill()
     }
     wait(for: [updateExpectation], timeout: 5)
-    collectionVC.collectionView.delegate?.collectionView?(collectionVC.collectionView,
-                                                          didHighlightItemAt: IndexPath(item: 0, section: 0))
+    collectionVC.collectionView.delegate?.collectionView?(
+      collectionVC.collectionView,
+      didHighlightItemAt: IndexPath(item: 0, section: 0)
+    )
     XCTAssertTrue(highlighted)
-    collectionVC.collectionView.delegate?.collectionView?(collectionVC.collectionView,
-                                                          didUnhighlightItemAt: IndexPath(item: 0, section: 0))
+    collectionVC.collectionView.delegate?.collectionView?(
+      collectionVC.collectionView,
+      didUnhighlightItemAt: IndexPath(item: 0, section: 0)
+    )
     XCTAssertFalse(highlighted)
   }
 

--- a/Source/Convenience/Presenter.swift
+++ b/Source/Convenience/Presenter.swift
@@ -5,9 +5,9 @@
 //
 
 import Foundation
-import RxSwift
+import RxRelay
 import UIKit
 
 public protocol Presenter {
-  var sections: Observable<[ListSection]> { get }
+  var sections: BehaviorRelay<[ListSection]> { get }
 }

--- a/Source/List/ListController.swift
+++ b/Source/List/ListController.swift
@@ -8,6 +8,7 @@ import Foundation
 import IGListKit
 import UIKit
 
+/// Manages the collection view state and updating the collection view to the provided ListSection's.
 public protocol ListController: AnyObject {
 
   typealias Completion = (Bool) -> Void
@@ -16,6 +17,7 @@ public protocol ListController: AnyObject {
   var reorderDelegate: ListControllerReorderDelegate? { get set }
   var sizeDelegate: ListControllerSizeDelegate? { get set }
   var scrollViewDelegate: UIScrollViewDelegate? { get set }
+
   var viewController: UIViewController? { get set }
   var collectionView: UICollectionView? { get set }
   var listSections: [ListSection] { get }


### PR DESCRIPTION
This prevents child coordinators from being retained if the navigator is used to directly remove its view controller instead of calling dismiss from the presenting coordinator.

It also cleans up the example app and catalog app to use Relay's instead of subjects and fixes the lint warnings.