### PR TITLE
Removed present(_:from:modalPresentationStyle:animated:animationCompletion) from CoordinatorNavigator

### DIFF
--- a/MinervaExample/Extensions/UIKitExtensions.swift
+++ b/MinervaExample/Extensions/UIKitExtensions.swift
@@ -77,9 +77,9 @@ extension CoordinatorNavigator {
     coordinator.addCloseButton { [weak self] child in
       self?.dismiss(child, animated: true)
     }
+    coordinator.navigator.setViewControllers([coordinator.baseViewController], animated: false)
     present(
       coordinator,
-      from: coordinator.navigator,
       modalPresentationStyle: modalPresentationStyle,
       animated: animated
     )

--- a/MinervaTests/Tests/CoordinationTests.swift
+++ b/MinervaTests/Tests/CoordinationTests.swift
@@ -52,7 +52,8 @@ public final class CoordinationTests: XCTestCase {
     let navigator = BasicNavigator(parent: nil)
     let childCoordinator = FakeCoordinator()
     let presentationExpectation = expectation(description: "Presentation")
-    rootCoordinator.present(childCoordinator, from: navigator, animated: false) {
+    navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
+    rootCoordinator.present(childCoordinator, animated: false) {
       presentationExpectation.fulfill()
     }
     wait(for: [presentationExpectation], timeout: 5)
@@ -94,7 +95,8 @@ public final class CoordinationTests: XCTestCase {
     let childCoordinator = FakeCoordinator()
     let navigator = BasicNavigator(parent: rootCoordinator.navigator)
     let presentationExpectation = expectation(description: "Presentation")
-    rootCoordinator.present(childCoordinator, from: navigator, animated: false) {
+    navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
+    rootCoordinator.present(childCoordinator, animated: false) {
       presentationExpectation.fulfill()
     }
     wait(for: [presentationExpectation], timeout: 5)

--- a/MinervaTests/Tests/NavigationCoordinatorTests.swift
+++ b/MinervaTests/Tests/NavigationCoordinatorTests.swift
@@ -53,7 +53,8 @@ public final class NavigationCoordinatorTests: XCTestCase {
     let navigator = NavigationCoordinatorNavigator(parent: nil)
     let childCoordinator = FakeCoordinator()
     let presentationExpectation = expectation(description: "Presentation")
-    rootCoordinator.present(childCoordinator, from: navigator, animated: false) {
+    navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
+    rootCoordinator.present(childCoordinator, animated: false) {
       presentationExpectation.fulfill()
     }
     wait(for: [presentationExpectation], timeout: 5)
@@ -95,7 +96,8 @@ public final class NavigationCoordinatorTests: XCTestCase {
     let childCoordinator = FakeCoordinator()
     let navigator = NavigationCoordinatorNavigator(parent: rootCoordinator.navigator)
     let presentationExpectation = expectation(description: "Presentation")
-    rootCoordinator.present(childCoordinator, from: navigator, animated: false) {
+    navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
+    rootCoordinator.present(childCoordinator, animated: false) {
       presentationExpectation.fulfill()
     }
     wait(for: [presentationExpectation], timeout: 5)

--- a/Source/Coordination/Coordinator.swift
+++ b/Source/Coordination/Coordinator.swift
@@ -56,28 +56,6 @@ extension CoordinatorNavigator {
 
   /// Presents a coordinator modally.
   /// - Parameter coordinator: The coordinator to display.
-  /// - Parameter navigator: The navigator to use for the presented view controller.
-  /// - Parameter modalPresentationStyle: The style used to present the coordinators view controller.
-  /// - Parameter animated: Whether or not to animate the transition of the coordinators view controller.
-  /// - Parameter animationCompletion: The completion to call when the presentation completes.
-  public func present(
-    _ coordinator: BaseCoordinatorPresentable,
-    from navigator: Navigator,
-    modalPresentationStyle: UIModalPresentationStyle? = nil,
-    animated: Bool = true,
-    animationCompletion: AnimationCompletion? = nil
-  ) {
-    navigator.setViewControllers([coordinator.baseViewController], animated: false)
-    present(
-      coordinator,
-      modalPresentationStyle: modalPresentationStyle,
-      animated: animated,
-      animationCompletion: animationCompletion
-    )
-  }
-
-  /// Presents a coordinator modally.
-  /// - Parameter coordinator: The coordinator to display.
   /// - Parameter modalPresentationStyle: The style used to present the coordinators view controller.
   /// - Parameter animated: Whether or not to animate the transition of the coordinators view controller.
   /// - Parameter animationCompletion: The completion to call when the presentation completes.


### PR DESCRIPTION
In order to simplify presenting coordinators w/in NavigationControllers by making it more similar to how UIKit handles presentation which is more familiar.

Also updated tests accordingly.