### PR TITLE
UIModalPresentationStyle NavigationCoordinator / NavigationCoordinatorNavigator Fix

### DIFF
--- a/MinervaTests/Tests/NavigationCoordinatorTests.swift
+++ b/MinervaTests/Tests/NavigationCoordinatorTests.swift
@@ -17,7 +17,7 @@ public final class NavigationCoordinatorTests: XCTestCase {
 
   override public func setUp() {
     super.setUp()
-    navigator = NavigationCoordinatorNavigator(parent: nil)
+    navigator = NavigationCoordinatorNavigator(parent: nil, modalPresentationStyle: .automatic)
     rootCoordinator = FakeCoordinator(navigator: navigator)
     navigator.setViewControllers([rootCoordinator.viewController], animated: false, completion: nil)
     UIApplication.shared.windows.first?.rootViewController = navigator.navigationController
@@ -50,7 +50,7 @@ public final class NavigationCoordinatorTests: XCTestCase {
 
   public func testPresentationFromNavigator() {
     XCTAssertNotNil(rootCoordinator.viewController.view)
-    let navigator = NavigationCoordinatorNavigator(parent: nil)
+    let navigator = NavigationCoordinatorNavigator(parent: nil, modalPresentationStyle: .automatic)
     let childCoordinator = FakeCoordinator()
     let presentationExpectation = expectation(description: "Presentation")
     navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
@@ -94,7 +94,10 @@ public final class NavigationCoordinatorTests: XCTestCase {
   public func testDismissalFromNavigator() {
     XCTAssertNotNil(rootCoordinator.viewController.view)
     let childCoordinator = FakeCoordinator()
-    let navigator = NavigationCoordinatorNavigator(parent: rootCoordinator.navigator)
+    let navigator = NavigationCoordinatorNavigator(
+      parent: rootCoordinator.navigator,
+      modalPresentationStyle: .automatic
+    )
     let presentationExpectation = expectation(description: "Presentation")
     navigator.setViewControllers([childCoordinator.baseViewController], animated: false)
     rootCoordinator.present(childCoordinator, animated: false) {

--- a/Source/Coordination/NavigationCoordinator.swift
+++ b/Source/Coordination/NavigationCoordinator.swift
@@ -25,11 +25,15 @@ open class NavigationCoordinator: NSObject, CoordinatorNavigator, CoordinatorPre
   public var childCoordinators: [Coordinator] = []
   private unowned let navigationController: UINavigationController
 
-  public init(navigationController: UINavigationController = UINavigationController()) {
+  public init(
+    navigationController: UINavigationController = UINavigationController(),
+    modalPresentationStyle: UIModalPresentationStyle
+  ) {
     self.navigationController = navigationController
     self.navigator = NavigationCoordinatorNavigator(
       parent: nil,
-      navigationController: navigationController
+      navigationController: navigationController,
+      modalPresentationStyle: modalPresentationStyle
     )
 
     super.init()

--- a/Source/Coordination/NavigationCoordinatorNavigator.swift
+++ b/Source/Coordination/NavigationCoordinatorNavigator.swift
@@ -10,10 +10,12 @@ import UIKit
 open class NavigationCoordinatorNavigator: NavigatorCommonImpl {
   public weak var navigationController: UINavigationController? { weakNavigationController }
 
-  override public init(
+  public init(
     parent: Navigator?,
-    navigationController: UINavigationController = UINavigationController()
+    navigationController: UINavigationController = UINavigationController(),
+    modalPresentationStyle: UIModalPresentationStyle
   ) {
+    navigationController.modalPresentationStyle = modalPresentationStyle
     super.init(parent: parent, navigationController: navigationController)
   }
 }


### PR DESCRIPTION
Update NavigationCoordinator and NavigationCoordinatorNavigator APIs to accept UIModalPresentationStyle on init so that the style can be set before the presentation controller is accessed.